### PR TITLE
Invalid Redirect Problem

### DIFF
--- a/gocoinpay/gocoinpay.php
+++ b/gocoinpay/gocoinpay.php
@@ -25,7 +25,7 @@ class Gocoinpay extends PaymentModule {
         $this->confirmUninstall = $this->l('Are you sure you want to delete your details?');
         /* Backward compatibility */
         require(_PS_MODULE_DIR_ . 'gocoinpay/backward_compatibility/backward.php');
-        $this->context->smarty->assign('base_url', _PS_BASE_URL_ . __PS_BASE_URI__);
+        $this->context->smarty->assign('base_url', 'https://'.Tools::getHttpHost().__PS_BASE_URI__);
         $this->context->smarty->assign('base_dir', __PS_BASE_URI__);
     }
 


### PR DESCRIPTION
Using `_PS_BASE_URL_ . __PS_BASE_URI__` will not return "https://" at the start of the URL if your store is not set to use HTTPS for every page (most people don't have HTTPS enabled for every page as it is unnecessary/a waste of resources). The problem with this is that when you use the configuration page to get the API token, GoCoin will say the URL to redirect to is invalid as the URL must start with "https".